### PR TITLE
Update Outputs library (OSK-5)

### DIFF
--- a/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
+++ b/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
@@ -14,7 +14,7 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="1.0.0" />
+		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="1.1.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----
The current library is not using the latest outputs package

Modifications
----
* Updated package version

Result
----
Latest version is used

Fixes #5