### PR TITLE
Add documentation and include new GetAsync extension (OSK-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # OSK.Storage.Abstractions
-A set of abstractions for saving and loading object data from storage in .NET.
+A set of abstractions for saving and loading object data from storage in .NET. Implementations will need to add logic for `IStorageService`
+and `StorageObejct` classes, which represents the main APIs users will access to get infromation and other data relating to their storage objects.
+`IStorageService` should be the single point in which users interact with the library or other implementations.
+
+# Contributions and Issues
+Any and all contributions are appreciated! Please be sure to follow the branch naming convention OSK-{issue number}-{deliminated}-{branch}-{name} as current workflows rely on it for automatic issue closure. Please submit issues for discussion and tracking using the github issue tracker.

--- a/src/OSK.Storage.Abstractions/IStorageService.cs
+++ b/src/OSK.Storage.Abstractions/IStorageService.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 
 namespace OSK.Storage.Abstractions
 {
+    /// <summary>
+    /// A storage service is capable of saving data to some sort of storage system, be it local or cloud based.
+    /// </summary>
+    /// <typeparam name="TSaveOptions">The specific save type options a storage service uses</typeparam>
+    /// <typeparam name="TSearchOptions">Specific search filtering options that can be applied to the storage service</typeparam>
     public interface IStorageService<TSaveOptions, TSearchOptions>
         where TSaveOptions : class
         where TSearchOptions : class

--- a/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
+++ b/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
@@ -8,13 +8,18 @@
 		<PackageTags>OpenSourceKingdom, OpenSource, Abstractions, Data, Object, Storage, Saving, Loading, Delete, Get, Serialize, Deserialize</PackageTags>
 		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Abstractions</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>CS1591</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="1.1.0" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="1.5.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Storage.Abstractions/StorageMetaData.cs
+++ b/src/OSK.Storage.Abstractions/StorageMetaData.cs
@@ -3,6 +3,9 @@ using System.IO;
 
 namespace OSK.Storage.Abstractions
 {
+    /// <summary>
+    /// Information relating to data that has been saved to a storage medium
+    /// </summary>
     public class StorageMetaData
     {
         #region Variables
@@ -13,10 +16,19 @@ namespace OSK.Storage.Abstractions
 
         public string FullStoragePath { get; }
 
+        /// <summary>
+        /// Whether the content is encrypted and must be decrypted to be usable
+        /// </summary>
         public bool IsEncrypted { get; }
 
+        /// <summary>
+        /// The byte size of the content
+        /// </summary>
         public long ContentSize { get; }
 
+        /// <summary>
+        /// The media type for the document being retrieved. See https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types for more information.
+        /// </summary>
         public string StorageMimeType { get; internal set; }
 
         public DateTime LastModifiedTimeUtc { get; }

--- a/src/OSK.Storage.Abstractions/StorageObject.cs
+++ b/src/OSK.Storage.Abstractions/StorageObject.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace OSK.Storage.Abstractions
 {
+    /// <summary>
+    /// A generic storage object that contains the raw data stream and the metadata for that object
+    /// </summary>
     public abstract class StorageObject : IDisposable
     {
         #region Variables
@@ -15,13 +18,17 @@ namespace OSK.Storage.Abstractions
 
         #endregion
 
-        #region Helpers
+        #region Constructors
 
         public StorageObject(Stream value, StorageMetaData metaData)
         {
             Value = value ?? throw new ArgumentNullException(nameof(value));
             MetaData = metaData ?? throw new ArgumentNullException(nameof(metaData));
         }
+
+        #endregion
+
+        #region Helpers
 
         public void Dispose()
         {

--- a/src/OSK.Storage.Abstractions/StorageServiceExtensions.cs
+++ b/src/OSK.Storage.Abstractions/StorageServiceExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OSK.Functions.Outputs.Abstractions;
+
+namespace OSK.Storage.Abstractions
+{
+    public static class StorageServiceExtensions
+    {
+        /// <summary>
+        /// Provides a direct way to retrieve an object of T, without needing any additional calls to the underlying storage object by the consumer that will raise errors through the IOutput response
+        /// </summary>
+        /// <typeparam name="TSaveOptions">The service save option type</typeparam>
+        /// <typeparam name="TSearchOptions">The service search option type</typeparam>
+        /// <typeparam name="TValue">The value type the storage object is expected to be</typeparam>
+        /// <param name="storageService">The storage service used to make the call</param>
+        /// <param name="fullStoragePath">The full path to the object location</param>
+        /// <param name="outputFactory">The output factory to generate an error response in case of a failure</param>
+        /// <param name="cancellationToken">The token for operation cancellation</param>
+        /// <returns>An <see cref="IOutput{TValue}"></see> containing the object if successful or standard error information if not</returns>
+        public static async Task<IOutput<TValue>> GetAsync<TSaveOptions, TSearchOptions, TValue>(this IStorageService<TSaveOptions, TSearchOptions> storageService,
+            string fullStoragePath, IOutputFactory outputFactory, CancellationToken cancellationToken = default)
+            where TSaveOptions : class
+            where TSearchOptions : class
+        {
+            try
+            {
+                var getResult = await storageService.GetAsync(fullStoragePath, cancellationToken);
+                if (getResult.IsSuccessful)
+                {
+                    var item = await getResult.Value.StreamAsAsync<TValue>(cancellationToken);
+                    return outputFactory.Success(item);
+                }
+
+                return getResult.AsType<TValue>();
+            }
+            catch (Exception ex)
+            {
+                return outputFactory.Exception<TValue>(ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----
There current library has little to no documentation and provides no quick access to getting an object of type <T>, so callers must make an additional call to stream the storage object to a specific type and replicate error handling

Modifications
----
* Added some documentation
* Added new extension method for `IStorageService` that allows callers to get an object of type <T> from the service without needing to replicae error handling logic/etc. across files and projects

Result
----
More documentation and easier access to GETting objects

Fixes #8