### PR TITLE
Update Outputs Dependency (OSK-10)

### DIFF
--- a/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
+++ b/src/OSK.Storage.Abstractions/OSK.Storage.Abstractions.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="1.5.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Abstractions" Version="2.2.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Storage.Abstractions/StorageServiceExtensions.cs
+++ b/src/OSK.Storage.Abstractions/StorageServiceExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using OSK.Functions.Outputs.Abstractions;
@@ -31,10 +29,10 @@ namespace OSK.Storage.Abstractions
                 if (getResult.IsSuccessful)
                 {
                     var item = await getResult.Value.StreamAsAsync<TValue>(cancellationToken);
-                    return outputFactory.Success(item);
+                    return outputFactory.Succeed(item);
                 }
 
-                return getResult.AsType<TValue>();
+                return getResult.AsOutput<TValue>();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Motivation
----
When using the latest outputs library with this project, the builds fail because it is not up to date

Modifications
----
* Update the Dependency

Result
----
The output Dependency should not cause builds to fail

Fixes #10